### PR TITLE
 🚑 Update distribute version for pypi HTTPS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## v1.2.3
+
+* Update version of distribute for pypi https requirement
+
 ## v1.2.2:
 
 * [COOK-2297] - more gracefully handle pip packages from VCS and

--- a/metadata.rb
+++ b/metadata.rb
@@ -3,7 +3,7 @@ maintainer        "Opscode, Inc."
 maintainer_email  "cookbooks@opscode.com"
 license           "Apache 2.0"
 description       "Installs Python, pip and virtualenv. Includes LWRPs for managing Python packages with `pip` and `virtualenv` isolated Python environments."
-version           "1.2.2"
+version           "1.2.3"
 
 depends           "build-essential"
 depends           "yum"


### PR DESCRIPTION
pypi.python.org doesn't redirect http to https any longer. The version
of 'distribute' here needed to be updated to get an updated version of
easy_install that uses https. The 'distribute' archive has changed to
be a zip rather than a tarball.

See here for more info:
https://mail.python.org/pipermail/distutils-sig/2017-October/031712.html